### PR TITLE
Fixing WebView warning by importing from correc...

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import {
   ActivityIndicator,
   StyleSheet,
-  View,
-  WebView
+  View
 } from 'react-native';
+import { WebView } from 'react-native-webview';
 import Readability from './util/readability';
 import cleanHtmlTemplate from './util/cleanHtmlTemplate';
 import cleanHtmlCss from './util/cleanHtmlCss';


### PR DESCRIPTION
...correct package, react-native-webview instead of react-native as it's being deprecated.